### PR TITLE
Fix auth routing 404 errors by removing /auth URL prefix

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -114,7 +114,7 @@ def create_app():
     app.context_processor(inject_user)
     
     app.register_blueprint(main_bp)
-    app.register_blueprint(auth_bp, url_prefix="/auth")
+    app.register_blueprint(auth_bp)
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
     app.register_blueprint(admin_bp, url_prefix="/admin")
     app.register_blueprint(billing_bp, url_prefix="/billing")

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -84,7 +84,7 @@
                     <a href="/pricing" class="dropdown-item">Upgrade to Premium</a>
                   {% endif %}
                   <div class="dropdown-divider"></div>
-                  <a href="/logout" class="dropdown-item">Logout</a>
+                  <a href="{{ url_for('auth.logout') }}" class="dropdown-item">Logout</a>
                 </div>
               </div>
             {% else %}

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -33,19 +33,19 @@ def admin_user(app):
         return user_id
 
 def test_register_success(client):
-    response = client.post('/auth/register', data={
+    response = client.post('/register', data={
         'email': 'test@example.com',
         'password': 'password123'
     })
     assert response.status_code == 302
 
 def test_register_duplicate_email(client):
-    client.post('/auth/register', data={
+    client.post('/register', data={
         'email': 'test@example.com',
         'password': 'password123'
     })
     
-    response = client.post('/auth/register', data={
+    response = client.post('/register', data={
         'email': 'test@example.com',
         'password': 'password456'
     })
@@ -57,14 +57,14 @@ def test_login_success(client, app):
         db.session.add(user)
         db.session.commit()
     
-    response = client.post('/auth/login', data={
+    response = client.post('/login', data={
         'email': 'test@example.com',
         'password': 'password123'
     })
     assert response.status_code == 302
 
 def test_login_invalid_credentials(client):
-    response = client.post('/auth/login', data={
+    response = client.post('/login', data={
         'email': 'nonexistent@example.com',
         'password': 'wrongpassword'
     })


### PR DESCRIPTION
- Remove url_prefix='/auth' from auth blueprint registration in app/__init__.py
- Update logout link to use url_for('auth.logout') in layout.html
- Fix test file URL inconsistencies in test_auth_routes.py
- Resolve 404 errors on /login and /register pages
- Maintain existing auth functionality while fixing routing
- All 7 auth tests now passing